### PR TITLE
Make the digest client configurable

### DIFF
--- a/digest_auth_client.go
+++ b/digest_auth_client.go
@@ -25,15 +25,15 @@ type DigestTransport struct {
 	Username string
 }
 
-// NewRequest creates a new DigestRequest object
-func NewRequest(username, password, method, uri, body string, client *http.Client, header http.Header) DigestRequest {
+// NewDigestRequest creates a new DigestRequest object
+func NewDigestRequest(username, password, method, uri, body string, client *http.Client, header http.Header) DigestRequest {
 	dr := DigestRequest{}
 	dr.UpdateRequest(username, password, method, uri, body, client, header)
 	return dr
 }
 
-// NewTransport creates a new DigestTransport object
-func NewTransport(username, password string, client *http.Client) DigestTransport {
+// NewDigestTransport creates a new DigestTransport object
+func NewDigestTransport(username, password string, client *http.Client) DigestTransport {
 	dt := DigestTransport{}
 	dt.Client = client
 	dt.Password = password
@@ -69,7 +69,7 @@ func (dt *DigestTransport) RoundTrip(req *http.Request) (resp *http.Response, er
 		body = buf.String()
 	}
 
-	dr := NewRequest(username, password, method, uri, body, dt.Client, header)
+	dr := NewDigestRequest(username, password, method, uri, body, dt.Client, header)
 	return dr.Execute()
 }
 
@@ -124,7 +124,7 @@ func (dr *DigestRequest) executeNewDigest(resp *http.Response) (resp2 *http.Resp
 		return nil, err
 	}
 
-	if resp2, err = dr.executeRequest(auth.toString()); err != nil {
+	if resp2, err = dr.executeDigestRequest(auth.toString()); err != nil {
 		return nil, err
 	}
 
@@ -140,10 +140,10 @@ func (dr *DigestRequest) executeExistingDigest() (resp *http.Response, err error
 	}
 	dr.Auth = auth
 
-	return dr.executeRequest(dr.Auth.toString())
+	return dr.executeDigestRequest(dr.Auth.toString())
 }
 
-func (dr *DigestRequest) executeRequest(authString string) (resp *http.Response, err error) {
+func (dr *DigestRequest) executeDigestRequest(authString string) (resp *http.Response, err error) {
 	var req *http.Request
 
 	if req, err = http.NewRequest(dr.Method, dr.Uri, bytes.NewReader([]byte(dr.Body))); err != nil {

--- a/digest_auth_client.go
+++ b/digest_auth_client.go
@@ -19,6 +19,7 @@ type DigestRequest struct {
 }
 
 type DigestTransport struct {
+	Client   *http.Client
 	Password string
 	Username string
 }
@@ -31,8 +32,9 @@ func NewRequest(username, password, method, uri, body string, client *http.Clien
 }
 
 // NewTransport creates a new DigestTransport object
-func NewTransport(username, password string) DigestTransport {
+func NewTransport(username, password string, client *http.Client) DigestTransport {
 	dt := DigestTransport{}
+	dt.Client = client
 	dt.Password = password
 	dt.Username = username
 	return dt
@@ -64,7 +66,7 @@ func (dt *DigestTransport) RoundTrip(req *http.Request) (resp *http.Response, er
 		body = buf.String()
 	}
 
-	dr := NewRequest(username, password, method, uri, body, nil)
+	dr := NewRequest(username, password, method, uri, body, dt.Client)
 	return dr.Execute()
 }
 

--- a/tests/manual-test.go
+++ b/tests/manual-test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	dac "github.com/xinsnake/go-http-digest-auth-client"
+	dac "github.com/iselind/go-http-digest-auth-client"
 )
 
 const (
@@ -21,7 +21,7 @@ func main() {
 	var body []byte
 	var err error
 
-	dr := dac.NewRequest(username, password, method, uri, "")
+	dr := dac.NewRequest(username, password, method, uri, "", nil)
 
 	if resp, err = dr.Execute(); err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
Now it is possible to modify the proxy function and the timeout used by the client, as well as keep the headers from the original request passed to the DigestTransport. 